### PR TITLE
toggle 5th bit to switch between upper and lower case letters

### DIFF
--- a/doc/03.rawInputAndOutput.md
+++ b/doc/03.rawInputAndOutput.md
@@ -15,7 +15,7 @@ doesn't have binary literals, and hexadecimal is more concise and readable once
 you get used to it.) In other words, it sets the upper 3 bits of the character
 to `0`. This mirrors what the <kbd>Ctrl</kbd> key does in the terminal: 
 it strips bits 5 and 6 from whatever key you press in combination with
-<kbd>Ctrl</kbd>, and sends that (As a rule, bit numbering starts from 0). 
+<kbd>Ctrl</kbd>, and sends that (By convention, bit numbering starts from 0). 
 The ASCII character set seems to be designed this way on purpose. 
 (It is also similarly designed so that you can set and clear bit 5 to switch 
 between lowercase and uppercase.)

--- a/doc/03.rawInputAndOutput.md
+++ b/doc/03.rawInputAndOutput.md
@@ -17,7 +17,7 @@ to `0`. This mirrors what the <kbd>Ctrl</kbd> key does in the terminal: it
 strips the 6th and 7th bits from whatever key you press in combination with
 <kbd>Ctrl</kbd>, and sends that. The ASCII character set seems to be designed
 this way on purpose. (It is also similarly designed so that you can set and
-clear the 6th bit to switch between lowercase and uppercase.)
+clear the 5th bit to switch between lowercase and uppercase.)
 
 ## Refactor keyboard input
 


### PR DESCRIPTION
Correction - toggling the 5th (instead of the 6th) bit switches between upper and lower case letters in ascii